### PR TITLE
hebrew for FARL (solves issue #6)

### DIFF
--- a/locale/he/he.cfg
+++ b/locale/he/he.cfg
@@ -1,0 +1,41 @@
+text-start = התחל
+text-stop = עצור
+text-startCC = אוטומטי
+text-stopCC = עצור אוטומטי
+text-settings = הגדרות
+text-save = שמור הגדרות
+tgl-signal = הצב אותות
+tgl-poles = הצב עמודים
+tgl-bridge = גשר על מים
+tgl-root = -root mode
+
+stg-poleSide = צד לשים עמוד:
+stg-flipPoles = הפוך שמאל-ימין
+stg-poleType = סוג עמוד:
+stg-poleMedium = עמוד בינוני
+stg-poleBig = עמוד גדול
+stg-side-left = שמאל
+stg-side-right = ימין
+stg-minPoles = הצבת עמוד מינימלית
+stg-signalDistance = מרחק בין אותות
+stg-ccNet = חבר כבל לוגיקה
+stg-ccNetWire = צבע
+stg-ccNetWire-green = ירוק
+stg-ccNetWire-red = אדום
+stg-ccNetWire-both = שניהם
+stg-blueprint = תרשימים
+stg-blueprint-read = קרא
+stg-blueprint-clear = נקה
+stg-collectWood = אסוף עץ
+stg-dropWood = זרוק עצים כאשר אין מקום
+
+[entity-name]
+farl=F.A.R.L.
+
+[item-description]
+farl=מניח פסי רכבת אוטומטי
+
+[item-name]
+farl=F.A.R.L.
+[recipe-name]
+farl=F.A.R.L.

--- a/locale/he/he.cfg
+++ b/locale/he/he.cfg
@@ -1,39 +1,39 @@
-text-start = δϊημ
-text-stop = ςφεψ
-text-startCC = ΰεθεξθι
-text-stopCC = ςφεψ ΰεθεξθι
-text-settings = δβγψεϊ
-text-save = ωξεψ δβγψεϊ
-tgl-signal = δφα ΰεϊεϊ
-tgl-poles = δφα ςξεγιν
-tgl-bridge = βωψ ςμ ξιν
+ο»Ώtext-start = ΧΧ—ΧªΧ”
+text-stop = Χ¨Χ•Χ¦ΧΆ
+text-startCC = Χ™ΧΧΧ•ΧΧ•Χ
+text-stopCC = Χ™ΧΧΧ•ΧΧ•Χ Χ¨Χ•Χ¦ΧΆ
+text-settings = ΧªΧ•Χ¨Χ“Χ’Χ”
+text-save = ΧªΧ•Χ¨Χ“Χ’Χ” Χ¨Χ•ΧΧ©
+tgl-signal = ΧªΧ•ΧªΧ•Χ Χ‘Χ¦Χ”
+tgl-poles = ΧΧ™Χ“Χ•ΧΧΆ Χ‘Χ¦Χ”
+tgl-bridge = ΧΧ™Χ ΧΧΆ Χ¨Χ©Χ’
 tgl-root = -root mode
 
-stg-poleSide = φγ μωιν ςξεγ:
-stg-flipPoles = δτεκ ωξΰμ-ιξιο
-stg-poleType = ρεβ ςξεγ:
-stg-poleMedium = ςξεγ αιπεπι
-stg-poleBig = ςξεγ βγεμ
-stg-side-left = ωξΰμ
-stg-side-right = ιξιο
-stg-minPoles = δφαϊ ςξεγ ξιπιξμιϊ
-stg-signalDistance = ξψηχ αιο ΰεϊεϊ
-stg-ccNet = ηαψ λαμ μεβιχδ
-stg-ccNetWire = φας
-stg-ccNetWire-green = ιψεχ
-stg-ccNetWire-red = ΰγεν
-stg-ccNetWire-both = ωπιδν
-stg-blueprint = ϊψωιξιν
-stg-blueprint-read = χψΰ
-stg-blueprint-clear = πχδ
-stg-collectWood = ΰρεσ ςυ
-stg-dropWood = ζψεχ ςφιν λΰωψ ΰιο ξχεν
+stg-poleSide = Χ“Χ•ΧΧΆ ΧΧ™Χ©Χ Χ“Χ¦:
+stg-flipPoles = ΧΧ™ΧΧ™-ΧΧΧΧ© ΧΧ•Χ¤Χ”
+stg-poleType = Χ“Χ•ΧΧΆ Χ’Χ•Χ΅:
+stg-poleMedium = Χ™Χ Χ•Χ Χ™Χ‘ Χ“Χ•ΧΧΆ
+stg-poleBig = ΧΧ•Χ“Χ’ Χ“Χ•ΧΧΆ
+stg-side-left = ΧΧΧΧ©
+stg-side-right = ΧΧ™ΧΧ™
+stg-minPoles = ΧªΧ™ΧΧΧ™Χ Χ™Χ Χ“Χ•ΧΧΆ ΧªΧ‘Χ¦Χ”
+stg-signalDistance = ΧªΧ•ΧªΧ•Χ ΧΧ™Χ‘ Χ§Χ—Χ¨Χ
+stg-ccNet = Χ”Χ§Χ™Χ’Χ•Χ ΧΧ‘Χ› Χ¨Χ‘Χ—
+stg-ccNetWire = ΧΆΧ‘Χ¦
+stg-ccNetWire-green = Χ§Χ•Χ¨Χ™
+stg-ccNetWire-red = ΧΧ•Χ“Χ
+stg-ccNetWire-both = ΧΧ”Χ™Χ Χ©
+stg-blueprint = ΧΧ™ΧΧ•ΧΧ¨Χ΅
+stg-blueprint-read = ΧΧ¨Χ§
+stg-blueprint-clear = Χ”Χ§Χ 
+stg-collectWood = Χ¥ΧΆ Χ£Χ•Χ΅Χ
+stg-dropWood = ΧΧ•Χ§Χ ΧΧ™Χ Χ¨Χ©ΧΧ› ΧΧ™Χ¦ΧΆ Χ§Χ•Χ¨Χ–
 
 [entity-name]
 farl=F.A.R.L.
 
 [item-description]
-farl=ξπιη τρι ψλαϊ ΰεθεξθι
+farl=Χ™ΧΧΧ•ΧΧ•Χ ΧªΧ‘Χ›Χ¨ Χ™Χ΅Χ¤ Χ—Χ™Χ Χ
 
 [item-name]
 farl=F.A.R.L.


### PR DESCRIPTION
made a hebrew locale file. inverted it so it is visable in 0.11.x and 0.12

 for 0.12.1 I need to uninvert it because there will be a code change in-game to invert the text that the devs will make
