### PR TITLE
re-inverted Hebrew text for 0.3.13 and Hebrew text changes

### DIFF
--- a/locale/he/he.cfg
+++ b/locale/he/he.cfg
@@ -1,0 +1,41 @@
+﻿text-start =התחל
+text-stop =עצור
+text-startCC =מצב שיוט
+text-stopCC =ביטול שיוט
+text-settings =הגדרות
+text-save =שמור הגדרות
+tgl-signal =הצב אותות
+tgl-poles =הצב עמודים
+tgl-bridge =גשר על מים
+tgl-root = -root mode
+
+stg-poleSide =:צד לשים עמוד
+stg-flipPoles =הפוך שמאל-ימין
+stg-poleType =:סוג עמוד
+stg-poleMedium =עמוד בינוני
+stg-poleBig =עמוד גדול
+stg-side-left =שמאל
+stg-side-right =ימין
+stg-minPoles =הצבת עמוד מינימלית
+stg-signalDistance =מרחק בין אותות
+stg-ccNet =חבר כבל לוגיקה
+stg-ccNetWire =צבע
+stg-ccNetWire-green =ירוק
+stg-ccNetWire-red =אדום
+stg-ccNetWire-both =שניהם
+stg-blueprint =סרטוטים
+stg-blueprint-read =קרא
+stg-blueprint-clear =נקה
+stg-collectWood =אסוף עץ
+stg-dropWood =זרוק עצים כאשר אין מקום
+
+[entity-name]
+farl=F.A.R.L.
+
+[item-description]
+farl=מניח פסי רכבת אוטומטי
+
+[item-name]
+farl=F.A.R.L.
+[recipe-name]
+farl=F.A.R.L.


### PR DESCRIPTION
Changes:
1. Factorio 0.12.1 has fixed the inverted Hebrew problem (finally) - so
   I re-inverted the text strings,
2. Changed startCC & stopCC to the Hebrew equivalent of CruiseControl
