### PR TITLE
Small optimizations

### DIFF
--- a/FARL.lua
+++ b/FARL.lua
@@ -70,7 +70,7 @@ end
 
 -- defines defines a direction as a number from 0 to 7, with its opposite calculateable by adding for and modulo 8
 function oppositedirection(direction)
-  return direction + 4 % 8;
+  return (direction + 4) % 8
 end
 
 function moveposition(pos, direction, distance)

--- a/FARL.lua
+++ b/FARL.lua
@@ -265,7 +265,6 @@ FARL = {
   removeTrees = function(self, area)
     apiCalls.count = apiCalls.count + 1
     local found = false
-    local
     for _, entity in pairs(self.surface.find_entities_filtered{area = area, type = "tree"}) do
       found = true
       entity.die()


### PR DESCRIPTION
I made a small amount of changes to lessen the cpu load during FARL usage. I don’t know how much, but every little bit helps I guess:

Calculation of opposite direction is down from 8 consecutive if statements to a single arithmetic equation.

Removal of entities has one less call to the expensive count/find_entities_filtered method. Setting a boolean flag (even multiple times) should be more efficient than searching for the same objects twice.

I’ve tested a bit on my save file and everything seemed to work without problems. I do not have a big base that drops FPS/UPS, so testing with a heavier load was not possible on my part.

On the forums (not yet posted) and on twitch I’m NearlyDutch. Maybe you’ve seen me in one of colonelwill’s streams, where I got the idea to look for optimization potential.
