### PR TITLE
Found some things when upgrading

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -174,7 +174,7 @@ local function on_configuration_changed(data)
     if oldVersion then
       if oldVersion < "0.5.13" then
         debugDump("Reset settings",true)
-        global = nil
+        global = {}
       elseif oldVersion < "0.5.19" then
         for name, p_settings in pairs(global.players) do
           if p_settings.bulldozer == nil then
@@ -206,8 +206,7 @@ local function on_configuration_changed(data)
             GUI.createGui(farl.driver)
           end
         end
-      end
-      if oldVersion < "0.5.21" then
+      elseif oldVersion < "0.5.21" then
         local tmp = {}
         local tmpBps = {}
         for i,player in pairs(game.players) do


### PR DESCRIPTION
I upgraded today from 0.4.3 to 0.5.22, had some trouble getting into my save game. These 2 changes worked for me.
It failed twice on line 214 `if global.players[player.name] then`.

It first failed on `global`, indexing a nil value. So I changed the `global = nil` definition to `global = {}`.
Then it failed on `player` being nil, I don't know when game.players is introduced, but it appears to return nil for the player in my case.
I solved it by making that `if` an `elseif`, but I have not idea if that is the correct fix.
