### PR TITLE
Added a button for FARL

### DIFF
--- a/GUI.lua
+++ b/GUI.lua
@@ -6,6 +6,10 @@ function endsWith(haystack,needle)--luacheck: allow defined top
     return needle=='' or string.sub(haystack,-string.len(needle))==needle
 end
 
+
+require("mod-gui")
+local modGui = _G.mod_gui
+
 GUI = {--luacheck: allow defined top
 
     ccWires = {
@@ -102,7 +106,28 @@ GUI = {--luacheck: allow defined top
         end
     end,
 
+    createButton = function(player)
+		local buttons = modGui.get_button_flow(player)
+			if not buttons.farl_button then
+				buttons.add({
+					type = "sprite-button",
+					name = "farl_button",
+					sprite = "item/farl",
+					style = modGui.button_style,
+					tooltip = {"farl_tooltip_button"}
+				})
+			end
+	end,
+	
+    destroyButton = function(player)
+		local buttons = modGui.get_button_flow(player)
+			if buttons.farl_button then
+				buttons.farl_button.destroy()
+			end
+	end,
+
     createGui = function(player)
+	
         if player.gui.left.farl ~= nil then return end
         local psettings = Settings.loadByPlayer(player)
         --GUI.init(player)

--- a/control.lua
+++ b/control.lua
@@ -4,6 +4,10 @@ require "Settings"
 require "FARL"
 require "GUI"
 
+
+require("mod-gui")
+local modGui = _G.mod_gui
+
 local v = require 'semver'
 
 MOD_NAME = "FARL"--luacheck: allow defined top
@@ -429,6 +433,11 @@ local function on_force_created(event)
 end
 
 local function on_gui_click(event)
+	if event.element.name == "farl_button" then
+		farl_button_click(event)
+		return
+	end
+
     local status, err = pcall(function()
         local index = event.player_index
         local player = game.players[index]
@@ -476,20 +485,34 @@ end
 function on_player_driving_changed_state(event)--luacheck: allow defined top
     local player = game.players[event.player_index]
     if isFARLLocomotive(player.vehicle) then
-        if player.gui.left.farl == nil then
-            local farl = FARL.onPlayerEnter(player)
-            GUI.createGui(player)
-            if farl then
-                GUI.updateGui(farl)
-            end
-        end
+		if modGui.get_button_flow(player).farl_button == nil then
+			GUI.createButton(player)
+		end
     end
-    if player.vehicle == nil and player.gui.left.farl ~= nil then
+    if player.vehicle == nil and (modGui.get_button_flow(player).farl_button ~= nil) then
         FARL.onPlayerLeave(player)
         debugDump("onPlayerLeave (driving state changed)")
-        GUI.destroyGui(player)
+		if player.gui.left.farl ~= nil then
+			GUI.destroyGui(player)
+		end
+		GUI.destroyButton(player)
     end
 end
+
+
+function farl_button_click (event)
+    local player = game.players[event.player_index]
+	if player.gui.left.farl == nil then
+		local farl = FARL.onPlayerEnter(player)
+		GUI.createGui(player)
+		if farl then
+			GUI.updateGui(farl)
+		end
+	else
+		GUI.destroyGui(player)
+	end
+end
+
 
 --function on_player_placed_equipment(event)
 --  local player = game.players[event.player_index]

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "FARL",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "factorio_version": "0.15",
   "title": "Fully Automated Rail Layer",
   "author": "Choumiko",

--- a/locale/de/tooltips.cfg
+++ b/locale/de/tooltips.cfg
@@ -6,3 +6,5 @@ farl_tooltip_signalEveryPole=Platziert Zugsignale mit jedem Strommast. Ignoriert
 farl_tooltip_place_ghosts=Places ghosts when the item is missing in the train\n Does not place rails and concrete 
 farl_tooltip_place_pole_entities=Places additional entities (poles, assemblers, inserters, etc..) whenever a pole is placed.\n Does not place walls or concrete
 farl_tooltip_place_walls=Places walls whenever a rail is built. 
+
+farl_tooltip_button=FARL

--- a/locale/en/tooltips.cfg
+++ b/locale/en/tooltips.cfg
@@ -6,3 +6,5 @@ farl_tooltip_signalEveryPole=Places signals with every pole. Ignores the "Distan
 farl_tooltip_place_ghosts=Places ghosts when the item is missing in the train\n Does not place rails and concrete 
 farl_tooltip_place_pole_entities=Places additional entities (poles, assemblers, inserters, etc..) whenever a pole is placed.\n Does not place walls or concrete
 farl_tooltip_place_walls=Places walls whenever a rail is built.
+
+farl_tooltip_button=FARL

--- a/locale/es-ES/tooltips.cfg
+++ b/locale/es-ES/tooltips.cfg
@@ -5,4 +5,6 @@ farl_tooltip_bridge=Use landfill to fill water when needed
 farl_tooltip_signalEveryPole=Places signals with every pole. Ignores the "Distance between rail signals" setting
 farl_tooltip_place_ghosts=Places ghosts when the item is missing in the train\n Does not place rails and concrete 
 farl_tooltip_place_pole_entities=Places additional entities (poles, assemblers, inserters, etc..) whenever a pole is placed.\n Does not place walls or concrete
-farl_tooltip_place_walls=Places walls whenever a rail is built.
+farl_tooltip_place_walls=Places walls whenever a rail is built. 
+
+farl_tooltip_button=FARL

--- a/locale/fr/tooltips.cfg
+++ b/locale/fr/tooltips.cfg
@@ -5,4 +5,6 @@ farl_tooltip_bridge=Use landfill to fill water when needed
 farl_tooltip_signalEveryPole=Place des signaux ferroviaires avec chaque poteau électrique. Ignore l'option "Distance entre les signaux ferroviaires".
 farl_tooltip_place_ghosts=Places ghosts when the item is missing in the train\n Does not place rails and concrete 
 farl_tooltip_place_pole_entities=Places additional entities (poles, assemblers, inserters, etc..) whenever a pole is placed.\n Does not place walls or concrete
-farl_tooltip_place_walls=Places walls whenever a rail is built.
+farl_tooltip_place_walls=Places walls whenever a rail is built. 
+
+farl_tooltip_button=FARL

--- a/locale/he/tooltips.cfg
+++ b/locale/he/tooltips.cfg
@@ -5,4 +5,6 @@ farl_tooltip_bridge=Use landfill to fill water when needed
 farl_tooltip_signalEveryPole=Places signals with every pole. Ignores the "Distance between rail signals" setting
 farl_tooltip_place_ghosts=Places ghosts when the item is missing in the train\n Does not place rails and concrete 
 farl_tooltip_place_pole_entities=Places additional entities (poles, assemblers, inserters, etc..) whenever a pole is placed.\n Does not place walls or concrete
-farl_tooltip_place_walls=Places walls whenever a rail is built.
+farl_tooltip_place_walls=Places walls whenever a rail is built. 
+
+farl_tooltip_button=FARL

--- a/locale/no/tooltips.cfg
+++ b/locale/no/tooltips.cfg
@@ -5,4 +5,6 @@ farl_tooltip_bridge=Use landfill to fill water when needed
 farl_tooltip_signalEveryPole=Places signals with every pole. Ignores the "Distance between rail signals" setting
 farl_tooltip_place_ghosts=Places ghosts when the item is missing in the train\n Does not place rails and concrete 
 farl_tooltip_place_pole_entities=Places additional entities (poles, assemblers, inserters, etc..) whenever a pole is placed.\n Does not place walls or concrete
-farl_tooltip_place_walls=Places walls whenever a rail is built.
+farl_tooltip_place_walls=Places walls whenever a rail is built. 
+
+farl_tooltip_button=FARL

--- a/locale/ru/tooltips.cfg
+++ b/locale/ru/tooltips.cfg
@@ -5,4 +5,6 @@ farl_tooltip_bridge=Use landfill to fill water when needed
 farl_tooltip_signalEveryPole=Places signals with every pole. Ignores the "Distance between rail signals" setting
 farl_tooltip_place_ghosts=Places ghosts when the item is missing in the train\n Does not place rails and concrete 
 farl_tooltip_place_pole_entities=Places additional entities (poles, assemblers, inserters, etc..) whenever a pole is placed.\n Does not place walls or concrete
-farl_tooltip_place_walls=Places walls whenever a rail is built.
+farl_tooltip_place_walls=Places walls whenever a rail is built. 
+
+farl_tooltip_button=FARL

--- a/locale/se/tooltips.cfg
+++ b/locale/se/tooltips.cfg
@@ -5,4 +5,6 @@ farl_tooltip_bridge=Use landfill to fill water when needed
 farl_tooltip_signalEveryPole=Places signals with every pole. Ignores the "Distance between rail signals" setting
 farl_tooltip_place_ghosts=Places ghosts when the item is missing in the train\n Does not place rails and concrete 
 farl_tooltip_place_pole_entities=Places additional entities (poles, assemblers, inserters, etc..) whenever a pole is placed.\n Does not place walls or concrete
-farl_tooltip_place_walls=Places walls whenever a rail is built.
+farl_tooltip_place_walls=Places walls whenever a rail is built. 
+
+farl_tooltip_button=FARL


### PR DESCRIPTION
Now, when entered a FARL, a button is shown, instead of GUI frame. The
frame is shown after clicking on the button.

The reason is I use my FARL / Shuttle train to move around, and I got
fed up with constant "popping up" of the frame.