### PR TITLE
Fix Lua exception when placing landfill

### DIFF
--- a/FARL.lua
+++ b/FARL.lua
@@ -930,7 +930,7 @@ FARL.fillWater = function(self, area)
                             dw = dw + 1
                         end
                         tile_prototypes[tileName] = tile_prototypes[tileName] or _tile_prototypes[tileName]
-                        table.insert(tiles, { old_tile = tile_prototypes[tileName], name = place_result, position = { x=x, y=y } })
+                        table.insert(tiles, { name = place_result, position = { x=x, y=y } })
                     end
                 end
             end
@@ -953,17 +953,6 @@ FARL.replaceWater = function(self, tiles, w, dw)
         if self:getCargoCount("landfill") >= lfills then
             self.surface.set_tiles(tiles)
             self:removeItemFromCargo("landfill", lfills)
-            local event = {
-                player_index = ((self.driver and self.driver.valid and self.driver.name ~= "farl_player") and (self.driver.index)) or ((self.startedBy and self.startedBy.valid) and self.startedBy.index),
-                surface_index = self.surface.index,
-                tiles = tiles, --array of {old_tile=.., position={x=..,y=y}}
-                item = game.item_prototypes['landfill'],
-                tile = game.tile_prototypes['landfill'],
-                --stack = nil,
-            }
-            event.player_index = event.player_index or 1
-            --log(serpent.block(event))
-            script.raise_event(defines.events.on_player_built_tile, event)
         end
     end
 end
@@ -1023,7 +1012,7 @@ FARL.placeConcrete = function(self, dir, rail)
                     dw = dw + 1
                 end
                 tile_prototypes[tileName] = tile_prototypes[tileName] or _tile_prototypes[tileName]
-                table.insert(tiles, { name = place_result, old_tile = tile_prototypes[tileName], position = { x=pos.x, y=pos.y } })
+                table.insert(tiles, { name = place_result, position = { x=pos.x, y=pos.y } })
                 table.insert(pave[name], entity)
             end
         elseif tileName ~= name and tileName ~= "out-of-map" then

--- a/control.lua
+++ b/control.lua
@@ -695,18 +695,6 @@ script.on_event("toggle-train-control", function(event)
     end
 end)
 
--- script.on_event({defines.events.on_player_built_tile,defines.events.on_robot_built_tile}, function(event)
---     --log(serpent.block(event))
---     if event.item then log("item " .. serpent.line({n=event.item.name,t=event.item.type})) end
---     log("tile " .. serpent.line(event.tile.name))
---     if event.stack then log("stack " .. serpent.line{n=event.stack.name,t=event.stack.type}) end
---     log("tiles")
---     log(serpent.block(event.tiles))
---     for _, t in pairs(event.tiles) do
---         log(serpent.line{old_tile = t.old_tile.name, p=t.position})
---     end
--- end)
-
 local command_to_button = {
     farl_read_bp = "blueprint",
     farl_clear_bp = "bpClear",


### PR DESCRIPTION
The purpose of this pull request is to fix the problem where Lua exception is thrown when FARL is placing bridges using the landfill:

```
  62.657 Script @__FARL__/lib_control.lua:21: 31294 Unexpected error: __FARL__/FARL.lua:2163: on_player_built_tile (ID 45) (45) can't be raised through script.
stack traceback:
	__FARL__/FARL.lua:966: in function 'replaceWater'
	__FARL__/FARL.lua:937: in function <__FARL__/FARL.lua:909>
	[C]: in function 'pcall'
	__FARL__/FARL.lua:909: in function 'fillWater'
	__FARL__/FARL.lua:723: in function 'prepareArea'
	__FARL__/FARL.lua:2163: in function 'placeRails'
	__FARL__/FARL.lua:496: in function 'update'
	__FARL__/control.lua:109: in function <__FARL__/control.lua:108>
	[C]: in function 'pcall'
	__FARL__/control.lua:108: in function <__FARL__/control.lua:81>
	[C]: in function 'pcall'
	__FARL__/control.lua:81: in function <__FARL__/control.lua:80>
```

The PR also drops related (commented-out) code.

Since Factorio [release 0.18.27](https://forums.factorio.com/viewtopic.php?t=85310), scripts are capable of raising only mod-specific events, and a limited number of built-in game events, as documented [on the API page](https://lua-api.factorio.com/latest/LuaBootstrap.html#LuaBootstrap.raise_event).

From what I can tell, the main user of this event was the [NiceFill](https://mods.factorio.com/mod/nicefill) mod (added to address #94 via 5daf72388cb9c1645db7b04aa9c346298469b288 for @staviq). Another approach to making the two mods interoperate would be to use the [script_raised_set_tiles](https://lua-api.factorio.com/latest/events.html#script_raised_set_tiles) event instead. This would require changes to NiceFill as well to handle that event, though, and I am not sure if it could cause issues with other mods that raise the event too.