### PR TITLE
fix crash if curved rail has no items_to_place_this

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -75,7 +75,7 @@ local function getRailTypes()
                 end
             end
         end
-        if proto.type == "curved-rail" then
+        if proto.type == "curved-rail" and proto.items_to_place_this then
             for _, item in pairs(proto.items_to_place_this) do
                 --log(serpent.block(item))
                 local item_proto = game.item_prototypes[item.name]


### PR DESCRIPTION
when checking "straight-rail" there is a check on "proto.items_to_place_this" before then trying to use pairs on "proto.items_to_place_this"

however when checking "curved-rail" there is no check on "proto.items_to_place_this" before then trying to use pairs on "proto.items_to_place_this"

this means that when another mod adds a type of rail for which there is no item to place it, FARL crashes with the following error:
```
Please report this error to the mod author.

Error while running event FARL::on_init()
__FARL__/control.lua:79: bad argument #1 of 2 to 'pairs' (table expected, got nil)
stack traceback:
    [C]: in function 'pairs'
    __FARL__/control.lua:79: in function 'getRailTypes'
    __FARL__/control.lua:228: in function <__FARL__/control.lua:222>
```

this PR adds the missing check to the "curved-rail" line