### PR TITLE
Better support for probability in item drops (fixes pyanodon trees)

### DIFF
--- a/FARL.lua
+++ b/FARL.lua
@@ -745,12 +745,15 @@ FARL.removeTrees = function(self, area)
                             if product.probability then
                                 if product.probability == 1 or (product.probability >= random()) then
                                     name = product.name
+                                    amount = product.amount
                                 end
                                 if name then
-                                    if product.amount_max == product.amount_min then
+                                    if product.amount_min and (product.amount_max == product.amount_min) then
                                         amount = product.amount_max
-                                    else
+                                    elseif product.amount_min and product.amount_max then
                                         amount = random(product.amount_min, product.amount_max)
+                                    else 
+                                        amount = product.amount
                                     end
                                     if amount and amount > 0 then
                                         self:addItemToCargo(name, ceil(amount/2))


### PR DESCRIPTION
This change makes probability in item drops work for trees and rocks in pyanodon's modpack (and probably other mods as well)
Link to relevant tree-drops source in pyal: https://github.com/pyanodon/pyalienlife/blob/master/prototypes/recipes/sap/recipes-sap.lua