### PR TITLE
Quick and dirty fix for Factorio 2.0 compatibility

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
   "name": "FARL",
-  "version": "4.1.3",
-  "factorio_version": "1.1",
+  "version": "4.1.4",
+  "factorio_version": "2.0",
   "title": "Fully Automated Rail Layer",
   "author": "Choumiko",
   "homepage": "https://github.com/Choumiko/FARL",


### PR DESCRIPTION
Changed factorio_version for 2.0 compatibility and upped mod version number.

Nothing has fundamentally changed with modding so this should work without any other changes (other than updating changelog.txt).